### PR TITLE
Added 'Settings' Dictionary property to Row, Area, & Control

### DIFF
--- a/src/Skybrud.Umbraco.GridData/GridArea.cs
+++ b/src/Skybrud.Umbraco.GridData/GridArea.cs
@@ -4,7 +4,8 @@ using Newtonsoft.Json.Linq;
 using Skybrud.Umbraco.GridData.ExtensionMethods;
 
 namespace Skybrud.Umbraco.GridData {
-    
+    using System.Collections.Generic;
+
     public class GridArea {
 
         [JsonProperty("grid")]
@@ -19,13 +20,16 @@ namespace Skybrud.Umbraco.GridData {
         [JsonProperty("controls")]
         public GridControl[] Controls { get; set; }
 
+        public Dictionary<string, string> Settings { get; set; }
+
         public static GridArea Parse(JObject obj) {
             JArray allowed = obj.GetArray("allowed");
             return new GridArea {
                 Grid = obj.GetInt32("grid"),
                 AllowAll = obj.GetBoolean("allowAll"),
                 Allowed = allowed == null ? new string[0] : allowed.Select(x => (string) x).ToArray(),
-                Controls = obj.GetArray("controls", GridControl.Parse)
+                Controls = obj.GetArray("controls", GridControl.Parse),
+                Settings = GridCustomSetting.Parse(obj)
             };
         }
 

--- a/src/Skybrud.Umbraco.GridData/GridControl.cs
+++ b/src/Skybrud.Umbraco.GridData/GridControl.cs
@@ -5,6 +5,7 @@ using Skybrud.Umbraco.GridData.ExtensionMethods;
 using Skybrud.Umbraco.GridData.Interfaces;
 
 namespace Skybrud.Umbraco.GridData {
+    using System.Collections.Generic;
 
     public class GridControl {
 
@@ -21,11 +22,14 @@ namespace Skybrud.Umbraco.GridData {
             return (T) Value;
         }
 
+        public Dictionary<string, string> Settings { get; set; }
+
         public static GridControl Parse(JObject obj) {
             
             GridControl control = new GridControl {
                 JObject = obj,
-                Editor = obj.GetObject("editor").ToObject<GridEditor>()
+                Editor = obj.GetObject("editor").ToObject<GridEditor>(),
+                Settings = GridCustomSetting.Parse(obj)
             };
 
             string alias = control.Editor.Alias;

--- a/src/Skybrud.Umbraco.GridData/GridCustomSetting.cs
+++ b/src/Skybrud.Umbraco.GridData/GridCustomSetting.cs
@@ -9,10 +9,6 @@ namespace Skybrud.Umbraco.GridData
 
     public class GridCustomSetting
     {
-        //public string Key { get; set; }
-
-        //public string Value { get; set; }
-
         public static Dictionary<string, string> Parse(JObject obj)
         {
             JObject cfg = obj.GetObject("config");
@@ -25,14 +21,9 @@ namespace Skybrud.Umbraco.GridData
                 {
                     settings.Add(property.Name, property.Value.ToString());
                 }
-
-                //return settings.ToArray();
             }
-            //else
-            //{
+
             return settings;
-            //return new GridCustomSetting[0];
-            //}
         }
     }
 }

--- a/src/Skybrud.Umbraco.GridData/GridCustomSetting.cs
+++ b/src/Skybrud.Umbraco.GridData/GridCustomSetting.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Skybrud.Umbraco.GridData.ExtensionMethods;
+
+namespace Skybrud.Umbraco.GridData
+{
+    using System.Collections.Generic;
+
+    public class GridCustomSetting
+    {
+        //public string Key { get; set; }
+
+        //public string Value { get; set; }
+
+        public static Dictionary<string, string> Parse(JObject obj)
+        {
+            JObject cfg = obj.GetObject("config");
+            
+            var settings = new Dictionary<string, string>();
+            
+            if (cfg != null)
+            {
+                foreach (JProperty property in cfg.Properties())
+                {
+                    settings.Add(property.Name, property.Value.ToString());
+                }
+
+                //return settings.ToArray();
+            }
+            //else
+            //{
+            return settings;
+            //return new GridCustomSetting[0];
+            //}
+        }
+    }
+}

--- a/src/Skybrud.Umbraco.GridData/GridRow.cs
+++ b/src/Skybrud.Umbraco.GridData/GridRow.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json.Linq;
 using Skybrud.Umbraco.GridData.ExtensionMethods;
 
 namespace Skybrud.Umbraco.GridData {
+    using System.Collections.Generic;
 
     public class GridRow {
 
@@ -15,11 +16,17 @@ namespace Skybrud.Umbraco.GridData {
         [JsonProperty("areas", Order = 2)]
         public GridArea[] Areas { get; set; }
 
+        public Dictionary<string, string> Settings { get; set; }
+
+        public JObject JObject { get; set; }
+
         public static GridRow Parse(JObject obj) {
             return new GridRow {
                 Id = obj.GetString("id"),
                 Name = obj.GetString("name"),
-                Areas = obj.GetArray("areas", GridArea.Parse) ?? new GridArea[0]
+                Areas = obj.GetArray("areas", GridArea.Parse) ?? new GridArea[0],
+                JObject = obj,
+                Settings = GridCustomSetting.Parse(obj)
             };
         }
 

--- a/src/Skybrud.Umbraco.GridData/Properties/AssemblyInfoGenerated.cs
+++ b/src/Skybrud.Umbraco.GridData/Properties/AssemblyInfoGenerated.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyFileVersion("0.0.122.7")]
+[assembly: AssemblyFileVersion("0.0.146.7")]
 

--- a/src/Skybrud.Umbraco.GridData/Skybrud.Umbraco.GridData.csproj
+++ b/src/Skybrud.Umbraco.GridData/Skybrud.Umbraco.GridData.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Converters\GridControlValueStringConverter.cs" />
     <Compile Include="ExtensionMethods\JArrayExtensionMethods.cs" />
     <Compile Include="ExtensionMethods\JObjectExtensionMethods.cs" />
+    <Compile Include="GridCustomSetting.cs" />
     <Compile Include="GridArea.cs" />
     <Compile Include="GridContext.cs" />
     <Compile Include="GridEditorConfig.cs" />


### PR DESCRIPTION
This new property provides custom settings data (which can be configured on the DataType for the Grid via the Umbraco UI) which might be stored with the grid value data.
