### PR TITLE
Adding a way to render grid sections like we render rows, this enable…

### DIFF
--- a/src/Skybrud.Umbraco.GridData/Extensions/TypedGridExtensionMethods.Sections.cs
+++ b/src/Skybrud.Umbraco.GridData/Extensions/TypedGridExtensionMethods.Sections.cs
@@ -1,0 +1,38 @@
+﻿using System.Web;
+using System.Web.Mvc;
+
+namespace Skybrud.Umbraco.GridData.Extensions {
+
+    /// <summary>
+    /// Class holding various extension methods for using the typed Grid.
+    /// </summary>
+    public static partial class TypedGridExtensionMethods {
+
+        /// <summary>
+        /// Gets the HTML of the specified <paramref name="section"/>.
+        /// </summary>
+        /// <param name="helper">The instance of <see cref="HtmlHelper"/> used for rendering the row.</param>
+        /// <param name="section">The section to be rendered.</param>
+        /// <returns>An instance of <see cref="HtmlString"/>.</returns>
+        public static HtmlString RenderGridSection(this HtmlHelper helper, GridSection section)
+        {
+            if (helper == null || section == null) return new HtmlString("");
+            return section.GetHtml(helper);
+        }
+
+        /// <summary>
+        /// Gets the HTML of the specified <paramref name="section"/>.
+        /// </summary>
+        /// <param name="helper">The instance of <see cref="HtmlHelper"/> used for rendering the row.</param>
+        /// <param name="section">The section to be rendered.</param>
+        /// <param name="partial">The partial view to be used for the rendering.</param>
+        /// <returns>An instance of <see cref="HtmlString"/>.</returns>
+        public static HtmlString RenderGridSection(this HtmlHelper helper, GridSection section, string partial)
+        {
+            if (helper == null || section == null) return new HtmlString("");
+            return section.GetHtml(helper, partial);
+        }
+
+    }
+
+}

--- a/src/Skybrud.Umbraco.GridData/GridSection.cs
+++ b/src/Skybrud.Umbraco.GridData/GridSection.cs
@@ -5,6 +5,10 @@ using Skybrud.Essentials.Json.Extensions;
 using Skybrud.Umbraco.GridData.Json;
 
 namespace Skybrud.Umbraco.GridData {
+    using System.Text.RegularExpressions;
+    using System.Web;
+    using System.Web.Mvc;
+    using System.Web.Mvc.Html;
 
     /// <summary>
     /// Class representing a section in an Umbraco Grid.
@@ -12,6 +16,11 @@ namespace Skybrud.Umbraco.GridData {
     public class GridSection : GridJsonObject {
 
         #region Properties
+
+        /// <summary>
+        /// Gets the section name.
+        /// </summary>
+        public string Name { get; private set; }
 
         /// <summary>
         /// Gets a reference to the parent <see cref="GridDataModel"/>.
@@ -73,6 +82,40 @@ namespace Skybrud.Umbraco.GridData {
             return Rows.Aggregate("", (current, row) => current + row.GetSearchableText());
         }
 
+        /// <summary>
+        /// Generates the HTML for the Grid row.
+        /// </summary>
+        /// <param name="helper">The <see cref="HtmlHelper"/> used for rendering the Grid row.</param>
+        /// <returns>Returns the Grid row as an instance of <see cref="HtmlString"/>.</returns>
+        public HtmlString GetHtml(HtmlHelper helper)
+        {
+            return GetHtml(helper, Name);
+        }
+
+        /// <summary>
+        /// Generates the HTML for the Grid row.
+        /// </summary>
+        /// <param name="helper">The <see cref="HtmlHelper"/> used for rendering the Grid row.</param>
+        /// <param name="partial">The alias or virtual path to the partial view for rendering the Grid row.</param>
+        /// <returns>Returns the Grid row as an instance of <see cref="HtmlString"/>.</returns>
+        public HtmlString GetHtml(HtmlHelper helper, string partial)
+        {
+
+            // Some input validation
+            if (helper == null) throw new ArgumentNullException("helper");
+            if (String.IsNullOrWhiteSpace(partial)) throw new ArgumentNullException("partial");
+
+            // Prepend the path to the "Sections" folder if not already specified
+            if (Regex.IsMatch(partial, "^[a-zA-Z0-9-_]+$"))
+            {
+                partial = "TypedGrid/Sections/" + partial;
+            }
+
+            // Render the partial view
+            return helper.Partial(partial, this);
+
+        }
+
         #endregion
 
         #region Static methods
@@ -90,7 +133,8 @@ namespace Skybrud.Umbraco.GridData {
             // Parse basic properties
             GridSection section = new GridSection(obj) {
                 Model = model,
-                Grid = obj.GetInt32("grid")
+                Grid = obj.GetInt32("grid"),
+                Name = obj.Root["name"].Value<string>()
             };
 
             // Parse the rows
@@ -104,7 +148,6 @@ namespace Skybrud.Umbraco.GridData {
 
             // Return the section
             return section;
-
         }
 
         #endregion

--- a/src/Skybrud.Umbraco.GridData/Skybrud.Umbraco.GridData.csproj
+++ b/src/Skybrud.Umbraco.GridData/Skybrud.Umbraco.GridData.csproj
@@ -270,6 +270,7 @@
     <Compile Include="Converters\Fanoe\FanoeGridConverter.cs" />
     <Compile Include="Converters\Umbraco\UmbracoGridConverter.cs" />
     <Compile Include="Converters\GridConverterCollection.cs" />
+    <Compile Include="Extensions\TypedGridExtensionMethods.Sections.cs" />
     <Compile Include="Extensions\TypedGridExtensionMethods.Rows.cs" />
     <Compile Include="Extensions\TypedGridExtensionMethods.Controls.cs" />
     <Compile Include="GridDictionaryItem.cs" />


### PR DESCRIPTION
…s us to have different partials for section specific names.

this pull request makes it possible to have grid section views and follows the same structure as the row rendering ex: "Views\Partials\TypedGrid\Sections\SectionName.cshtml"